### PR TITLE
Add the ability to specify the return file type

### DIFF
--- a/gleam.toml
+++ b/gleam.toml
@@ -10,6 +10,7 @@ links = [{ title = "Main Globlin Package", href = "https://hexdocs.pm/globlin/in
 gleam_stdlib = ">= 0.34.0 and < 2.0.0"
 simplifile = ">= 2.0.1 and < 3.0.0"
 globlin = ">= 2.0.0 and < 3.0.0"
+filepath = ">= 1.0.0 and < 2.0.0"
 
 [dev-dependencies]
 gleeunit = ">= 1.0.0 and < 2.0.0"

--- a/manifest.toml
+++ b/manifest.toml
@@ -10,6 +10,7 @@ packages = [
 ]
 
 [requirements]
+filepath = { version = ">= 1.0.0 and < 2.0.0" }
 gleam_stdlib = { version = ">= 0.34.0 and < 2.0.0" }
 gleeunit = { version = ">= 1.0.0 and < 2.0.0" }
 globlin = { version = ">= 2.0.0 and < 3.0.0" }

--- a/src/globlin_fs.gleam
+++ b/src/globlin_fs.gleam
@@ -1,3 +1,4 @@
+import filepath
 import gleam/list
 import globlin
 import simplifile
@@ -6,22 +7,115 @@ import simplifile
 pub type FileError =
   simplifile.FileError
 
-/// Glob files from the current working directory.
-pub fn glob(pattern: globlin.Pattern) -> Result(List(String), FileError) {
+/// Used to determine which files should be returned by the glob function.
+pub type FileType {
+  /// Regular files that are not directories or symlinks.
+  RegularFiles
+  /// Directories that are not symlinks.
+  Directories
+  /// Both regular files and directories that are not symlinks.
+  AllFiles
+}
+
+/// Use the specified glob pattern to return a list of the expected file type
+/// starting from the current working directory.
+/// 
+/// Note: No order is guaranteed for the resulting path list.
+pub fn glob(
+  pattern pattern: globlin.Pattern,
+  returning file_type: FileType,
+) -> Result(List(String), FileError) {
   case simplifile.current_directory() {
-    Ok(directory) -> glob_from(pattern:, directory:)
+    Ok(directory) -> glob_from(pattern:, directory:, returning: file_type)
     Error(err) -> Error(err)
   }
 }
 
-/// Glob files from a chosen directory.
+/// Use the specified glob pattern to return a list of the expected file type
+/// starting from the provided directory.
+/// 
+/// Note: No order is guaranteed for the resulting path list.
 pub fn glob_from(
   pattern pattern: globlin.Pattern,
   directory directory: String,
+  returning file_type: FileType,
 ) -> Result(List(String), FileError) {
-  case simplifile.get_files(in: directory) {
-    Ok(files) ->
-      Ok(list.filter(files, keeping: globlin.match_pattern(pattern:, path: _)))
+  let file_getter = case file_type {
+    RegularFiles -> collect_files(_, [], is_file)
+    Directories -> collect_files(_, [], is_directory)
+    AllFiles -> collect_files(_, [], is_file_or_directory)
+  }
+  let keeping = globlin.match_pattern(pattern:, path: _)
+
+  case file_getter(directory) {
+    Ok(files) -> Ok(list.filter(files, keeping:))
+    Error(err) -> Error(err)
+  }
+}
+
+// Recursively collect files of the expected types based on the keeping function provided.
+fn collect_files(
+  directory: String,
+  files: List(String),
+  keeping: IsFileType,
+) -> Result(List(String), FileError) {
+  case simplifile.read_directory(directory) {
+    Ok(contents) -> {
+      list.try_fold(over: contents, from: files, with: fn(acc, content) {
+        let path = filepath.join(directory, content)
+
+        case keeping(path) {
+          Ok(keep_path) -> {
+            let acc = case keep_path {
+              True -> [path, ..acc]
+              False -> acc
+            }
+
+            case is_directory(path) {
+              Ok(True) -> collect_files(path, acc, keeping)
+              Ok(False) -> Ok(acc)
+              Error(err) -> Error(err)
+            }
+          }
+          Error(err) -> Error(err)
+        }
+      })
+    }
+    Error(err) -> Error(err)
+  }
+}
+
+//--- File Type Checkers ---
+
+type IsFileType =
+  fn(String) -> Result(Bool, FileError)
+
+fn is_file(path: String) -> Result(Bool, FileError) {
+  case simplifile.is_symlink(path) {
+    Ok(True) -> Ok(False)
+    Ok(False) -> {
+      case simplifile.is_directory(path) {
+        Ok(True) -> Ok(False)
+        Ok(False) -> simplifile.is_file(path)
+        Error(err) -> Error(err)
+      }
+    }
+    Error(err) -> Error(err)
+  }
+}
+
+fn is_directory(path: String) -> Result(Bool, FileError) {
+  case simplifile.is_symlink(path) {
+    Ok(True) -> Ok(False)
+    Ok(False) -> simplifile.is_directory(path)
+    Error(err) -> Error(err)
+  }
+}
+
+fn is_file_or_directory(path: String) -> Result(Bool, FileError) {
+  case simplifile.is_symlink(path) {
+    Ok(True) -> Ok(False)
+    Ok(False) -> simplifile.is_file(path)
     Error(err) -> Error(err)
   }
 }

--- a/test/globlin_fs_test.gleam
+++ b/test/globlin_fs_test.gleam
@@ -9,13 +9,24 @@ pub fn main() {
   gleeunit.main()
 }
 
-pub fn glob_test() {
+pub fn glob_files_test() {
   globlin.new_pattern("**/test/*.gleam")
   |> should.be_ok
-  |> globlin_fs.glob
+  |> globlin_fs.glob(returning: globlin_fs.RegularFiles)
   |> should.be_ok
   |> list.first
   |> should.be_ok
   |> string.ends_with("/test/globlin_fs_test.gleam")
+  |> should.be_true
+}
+
+pub fn glob_directories_test() {
+  globlin.new_pattern("**/.github/work*/**")
+  |> should.be_ok
+  |> globlin_fs.glob(returning: globlin_fs.Directories)
+  |> should.be_ok
+  |> list.first
+  |> should.be_ok
+  |> string.ends_with("/.github/workflows")
   |> should.be_true
 }


### PR DESCRIPTION
I saw this in another glob library and I thought it could be useful here too. Basically you will now be able to specify which file types you want to return from the glob. So if you only want to glob directories or regular files that should work now. You can also specify that you want everything as well.

I've decided to ignore symlinks entirely here. I'm not sure if that's the right approach but it seems like the least surprising thing to do. I guess we'll see if anyone has a strong opinion about that.

The method here is recursive but not tail-recursive. I don't think that will be a problem though since the number of stackframes will in the worst-case scenario equal the number of path components which shouldn't end up being that large on any platform. It's also simpler to write that sort of algorithm here.

I should also mention that the logic here is similar to that found in the `simplifile.get_files` method found in simplifile v2.1.


Closes #1 